### PR TITLE
Added quick and dirty method to find multi-disk titles and create an m3u playlist for them

### DIFF
--- a/RomSorter5/Form2.Designer.cs
+++ b/RomSorter5/Form2.Designer.cs
@@ -53,14 +53,15 @@
             this.chkZipInsteadOfFolders = new System.Windows.Forms.CheckBox();
             this.btn1G1R = new System.Windows.Forms.Button();
             this.btnEverdrive = new System.Windows.Forms.Button();
+            this.btnCreateM3uPlaylists = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // btnDetectDupes
             // 
-            this.btnDetectDupes.Location = new System.Drawing.Point(240, 196);
-            this.btnDetectDupes.Margin = new System.Windows.Forms.Padding(6);
+            this.btnDetectDupes.Location = new System.Drawing.Point(185, 153);
+            this.btnDetectDupes.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.btnDetectDupes.Name = "btnDetectDupes";
-            this.btnDetectDupes.Size = new System.Drawing.Size(206, 141);
+            this.btnDetectDupes.Size = new System.Drawing.Size(158, 110);
             this.btnDetectDupes.TabIndex = 0;
             this.btnDetectDupes.Text = "Detect Duplicate (Unzipped) Files";
             this.btnDetectDupes.UseVisualStyleBackColor = true;
@@ -70,18 +71,18 @@
             // 
             this.txtDatPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtDatPath.Location = new System.Drawing.Point(362, 17);
-            this.txtDatPath.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.txtDatPath.Location = new System.Drawing.Point(278, 13);
+            this.txtDatPath.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtDatPath.Name = "txtDatPath";
-            this.txtDatPath.Size = new System.Drawing.Size(517, 39);
+            this.txtDatPath.Size = new System.Drawing.Size(399, 31);
             this.txtDatPath.TabIndex = 15;
             // 
             // btnDatFolderSelect
             // 
-            this.btnDatFolderSelect.Location = new System.Drawing.Point(253, 9);
-            this.btnDatFolderSelect.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.btnDatFolderSelect.Location = new System.Drawing.Point(195, 7);
+            this.btnDatFolderSelect.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.btnDatFolderSelect.Name = "btnDatFolderSelect";
-            this.btnDatFolderSelect.Size = new System.Drawing.Size(102, 51);
+            this.btnDatFolderSelect.Size = new System.Drawing.Size(78, 40);
             this.btnDatFolderSelect.TabIndex = 14;
             this.btnDatFolderSelect.Text = "Select";
             this.btnDatFolderSelect.UseVisualStyleBackColor = true;
@@ -90,10 +91,9 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(20, 19);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(15, 15);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(213, 32);
+            this.label1.Size = new System.Drawing.Size(159, 25);
             this.label1.TabIndex = 13;
             this.label1.Text = "Dat File: (Optional)";
             // 
@@ -101,18 +101,18 @@
             // 
             this.txtRomPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.txtRomPath.Location = new System.Drawing.Point(362, 73);
-            this.txtRomPath.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.txtRomPath.Location = new System.Drawing.Point(278, 57);
+            this.txtRomPath.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtRomPath.Name = "txtRomPath";
-            this.txtRomPath.Size = new System.Drawing.Size(517, 39);
+            this.txtRomPath.Size = new System.Drawing.Size(399, 31);
             this.txtRomPath.TabIndex = 18;
             // 
             // btnRomFolderSelect
             // 
-            this.btnRomFolderSelect.Location = new System.Drawing.Point(253, 64);
-            this.btnRomFolderSelect.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.btnRomFolderSelect.Location = new System.Drawing.Point(195, 50);
+            this.btnRomFolderSelect.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.btnRomFolderSelect.Name = "btnRomFolderSelect";
-            this.btnRomFolderSelect.Size = new System.Drawing.Size(102, 51);
+            this.btnRomFolderSelect.Size = new System.Drawing.Size(78, 40);
             this.btnRomFolderSelect.TabIndex = 17;
             this.btnRomFolderSelect.Text = "Select";
             this.btnRomFolderSelect.UseVisualStyleBackColor = true;
@@ -121,10 +121,9 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(20, 77);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(15, 60);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(173, 32);
+            this.label2.Size = new System.Drawing.Size(129, 25);
             this.label2.TabIndex = 16;
             this.label2.Text = "Current Folder:";
             // 
@@ -138,29 +137,28 @@
             // 
             this.progressBar1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progressBar1.Location = new System.Drawing.Point(20, 830);
-            this.progressBar1.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.progressBar1.Location = new System.Drawing.Point(15, 648);
+            this.progressBar1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.progressBar1.Name = "progressBar1";
-            this.progressBar1.Size = new System.Drawing.Size(869, 66);
+            this.progressBar1.Size = new System.Drawing.Size(668, 52);
             this.progressBar1.TabIndex = 20;
             // 
             // lblStatus
             // 
             this.lblStatus.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.lblStatus.AutoSize = true;
-            this.lblStatus.Location = new System.Drawing.Point(22, 917);
-            this.lblStatus.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblStatus.Location = new System.Drawing.Point(17, 716);
             this.lblStatus.Name = "lblStatus";
-            this.lblStatus.Size = new System.Drawing.Size(53, 32);
+            this.lblStatus.Size = new System.Drawing.Size(41, 25);
             this.lblStatus.TabIndex = 19;
             this.lblStatus.Text = "Idle";
             // 
             // btnUnzipAll
             // 
-            this.btnUnzipAll.Location = new System.Drawing.Point(457, 196);
-            this.btnUnzipAll.Margin = new System.Windows.Forms.Padding(6);
+            this.btnUnzipAll.Location = new System.Drawing.Point(352, 153);
+            this.btnUnzipAll.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.btnUnzipAll.Name = "btnUnzipAll";
-            this.btnUnzipAll.Size = new System.Drawing.Size(206, 141);
+            this.btnUnzipAll.Size = new System.Drawing.Size(158, 110);
             this.btnUnzipAll.TabIndex = 21;
             this.btnUnzipAll.Text = "Unzip All Files";
             this.btnUnzipAll.UseVisualStyleBackColor = true;
@@ -168,10 +166,10 @@
             // 
             // btnZipAllFiles
             // 
-            this.btnZipAllFiles.Location = new System.Drawing.Point(22, 196);
-            this.btnZipAllFiles.Margin = new System.Windows.Forms.Padding(6);
+            this.btnZipAllFiles.Location = new System.Drawing.Point(17, 153);
+            this.btnZipAllFiles.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.btnZipAllFiles.Name = "btnZipAllFiles";
-            this.btnZipAllFiles.Size = new System.Drawing.Size(206, 141);
+            this.btnZipAllFiles.Size = new System.Drawing.Size(158, 110);
             this.btnZipAllFiles.TabIndex = 22;
             this.btnZipAllFiles.Text = "Zip (or Convert) All Files";
             this.btnZipAllFiles.UseVisualStyleBackColor = true;
@@ -179,10 +177,10 @@
             // 
             // btnIdentifyAndZip
             // 
-            this.btnIdentifyAndZip.Location = new System.Drawing.Point(22, 503);
-            this.btnIdentifyAndZip.Margin = new System.Windows.Forms.Padding(6);
+            this.btnIdentifyAndZip.Location = new System.Drawing.Point(17, 393);
+            this.btnIdentifyAndZip.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.btnIdentifyAndZip.Name = "btnIdentifyAndZip";
-            this.btnIdentifyAndZip.Size = new System.Drawing.Size(206, 141);
+            this.btnIdentifyAndZip.Size = new System.Drawing.Size(158, 110);
             this.btnIdentifyAndZip.TabIndex = 23;
             this.btnIdentifyAndZip.Text = "Rename Single-File Games";
             this.btnIdentifyAndZip.UseVisualStyleBackColor = true;
@@ -191,10 +189,10 @@
             // chkMoveUnidentified
             // 
             this.chkMoveUnidentified.AutoSize = true;
-            this.chkMoveUnidentified.Location = new System.Drawing.Point(22, 130);
-            this.chkMoveUnidentified.Margin = new System.Windows.Forms.Padding(6);
+            this.chkMoveUnidentified.Location = new System.Drawing.Point(17, 102);
+            this.chkMoveUnidentified.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.chkMoveUnidentified.Name = "chkMoveUnidentified";
-            this.chkMoveUnidentified.Size = new System.Drawing.Size(611, 36);
+            this.chkMoveUnidentified.Size = new System.Drawing.Size(453, 29);
             this.chkMoveUnidentified.TabIndex = 25;
             this.chkMoveUnidentified.Text = "Move unidentified files to sub-folder during Rename";
             this.chkMoveUnidentified.UseVisualStyleBackColor = true;
@@ -202,10 +200,10 @@
             // chkUseIDOffsets
             // 
             this.chkUseIDOffsets.AutoSize = true;
-            this.chkUseIDOffsets.Location = new System.Drawing.Point(700, 523);
-            this.chkUseIDOffsets.Margin = new System.Windows.Forms.Padding(6);
+            this.chkUseIDOffsets.Location = new System.Drawing.Point(538, 409);
+            this.chkUseIDOffsets.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.chkUseIDOffsets.Name = "chkUseIDOffsets";
-            this.chkUseIDOffsets.Size = new System.Drawing.Size(313, 36);
+            this.chkUseIDOffsets.Size = new System.Drawing.Size(240, 29);
             this.chkUseIDOffsets.TabIndex = 26;
             this.chkUseIDOffsets.Text = "TODO Use No-Intro DATs";
             this.chkUseIDOffsets.UseVisualStyleBackColor = true;
@@ -213,10 +211,10 @@
             // 
             // btnCatalog
             // 
-            this.btnCatalog.Location = new System.Drawing.Point(22, 350);
-            this.btnCatalog.Margin = new System.Windows.Forms.Padding(6);
+            this.btnCatalog.Location = new System.Drawing.Point(17, 273);
+            this.btnCatalog.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.btnCatalog.Name = "btnCatalog";
-            this.btnCatalog.Size = new System.Drawing.Size(206, 141);
+            this.btnCatalog.Size = new System.Drawing.Size(158, 110);
             this.btnCatalog.TabIndex = 27;
             this.btnCatalog.Text = "Catalog Files";
             this.btnCatalog.UseVisualStyleBackColor = true;
@@ -224,10 +222,10 @@
             // 
             // btnVerify
             // 
-            this.btnVerify.Location = new System.Drawing.Point(240, 350);
-            this.btnVerify.Margin = new System.Windows.Forms.Padding(6);
+            this.btnVerify.Location = new System.Drawing.Point(185, 273);
+            this.btnVerify.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.btnVerify.Name = "btnVerify";
-            this.btnVerify.Size = new System.Drawing.Size(206, 141);
+            this.btnVerify.Size = new System.Drawing.Size(158, 110);
             this.btnVerify.TabIndex = 28;
             this.btnVerify.Text = "Verify Catalog";
             this.btnVerify.UseVisualStyleBackColor = true;
@@ -235,10 +233,10 @@
             // 
             // btnRenameMultiFile
             // 
-            this.btnRenameMultiFile.Location = new System.Drawing.Point(716, 646);
-            this.btnRenameMultiFile.Margin = new System.Windows.Forms.Padding(6);
+            this.btnRenameMultiFile.Location = new System.Drawing.Point(551, 505);
+            this.btnRenameMultiFile.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.btnRenameMultiFile.Name = "btnRenameMultiFile";
-            this.btnRenameMultiFile.Size = new System.Drawing.Size(206, 141);
+            this.btnRenameMultiFile.Size = new System.Drawing.Size(158, 110);
             this.btnRenameMultiFile.TabIndex = 29;
             this.btnRenameMultiFile.Text = "Rename Multi-File Games (Incomplete)";
             this.btnRenameMultiFile.UseVisualStyleBackColor = true;
@@ -247,10 +245,10 @@
             // 
             // btnCreateChds
             // 
-            this.btnCreateChds.Location = new System.Drawing.Point(22, 657);
-            this.btnCreateChds.Margin = new System.Windows.Forms.Padding(6);
+            this.btnCreateChds.Location = new System.Drawing.Point(17, 513);
+            this.btnCreateChds.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.btnCreateChds.Name = "btnCreateChds";
-            this.btnCreateChds.Size = new System.Drawing.Size(206, 141);
+            this.btnCreateChds.Size = new System.Drawing.Size(158, 110);
             this.btnCreateChds.TabIndex = 30;
             this.btnCreateChds.Text = "Create CHD Files";
             this.btnCreateChds.UseVisualStyleBackColor = true;
@@ -258,10 +256,10 @@
             // 
             // btnExtractChds
             // 
-            this.btnExtractChds.Location = new System.Drawing.Point(240, 657);
-            this.btnExtractChds.Margin = new System.Windows.Forms.Padding(6);
+            this.btnExtractChds.Location = new System.Drawing.Point(185, 513);
+            this.btnExtractChds.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.btnExtractChds.Name = "btnExtractChds";
-            this.btnExtractChds.Size = new System.Drawing.Size(206, 141);
+            this.btnExtractChds.Size = new System.Drawing.Size(158, 110);
             this.btnExtractChds.TabIndex = 31;
             this.btnExtractChds.Text = "Extract CHD Files";
             this.btnExtractChds.UseVisualStyleBackColor = true;
@@ -269,10 +267,10 @@
             // 
             // btnMakeDat
             // 
-            this.btnMakeDat.Location = new System.Drawing.Point(457, 350);
-            this.btnMakeDat.Margin = new System.Windows.Forms.Padding(6);
+            this.btnMakeDat.Location = new System.Drawing.Point(352, 273);
+            this.btnMakeDat.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.btnMakeDat.Name = "btnMakeDat";
-            this.btnMakeDat.Size = new System.Drawing.Size(206, 141);
+            this.btnMakeDat.Size = new System.Drawing.Size(158, 110);
             this.btnMakeDat.TabIndex = 32;
             this.btnMakeDat.Text = "Make DAT File for Folder";
             this.btnMakeDat.UseVisualStyleBackColor = true;
@@ -281,20 +279,19 @@
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(2225, 245);
-            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label3.Location = new System.Drawing.Point(1712, 191);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(280, 32);
+            this.label3.Size = new System.Drawing.Size(209, 25);
             this.label3.TabIndex = 33;
             this.label3.Text = "Nothing over here, sorry.";
             // 
             // chkZipInsteadOfFolders
             // 
             this.chkZipInsteadOfFolders.AutoSize = true;
-            this.chkZipInsteadOfFolders.Location = new System.Drawing.Point(700, 576);
-            this.chkZipInsteadOfFolders.Margin = new System.Windows.Forms.Padding(6);
+            this.chkZipInsteadOfFolders.Location = new System.Drawing.Point(538, 450);
+            this.chkZipInsteadOfFolders.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.chkZipInsteadOfFolders.Name = "chkZipInsteadOfFolders";
-            this.chkZipInsteadOfFolders.Size = new System.Drawing.Size(405, 36);
+            this.chkZipInsteadOfFolders.Size = new System.Drawing.Size(306, 29);
             this.chkZipInsteadOfFolders.TabIndex = 34;
             this.chkZipInsteadOfFolders.Text = "TODO Use Zips instead of Folders";
             this.chkZipInsteadOfFolders.UseVisualStyleBackColor = true;
@@ -302,10 +299,10 @@
             // 
             // btn1G1R
             // 
-            this.btn1G1R.Location = new System.Drawing.Point(240, 503);
-            this.btn1G1R.Margin = new System.Windows.Forms.Padding(6);
+            this.btn1G1R.Location = new System.Drawing.Point(185, 393);
+            this.btn1G1R.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.btn1G1R.Name = "btn1G1R";
-            this.btn1G1R.Size = new System.Drawing.Size(206, 141);
+            this.btn1G1R.Size = new System.Drawing.Size(158, 110);
             this.btn1G1R.TabIndex = 35;
             this.btn1G1R.Text = "Make 1G1R Set";
             this.btn1G1R.UseVisualStyleBackColor = true;
@@ -313,20 +310,32 @@
             // 
             // btnEverdrive
             // 
-            this.btnEverdrive.Location = new System.Drawing.Point(457, 503);
-            this.btnEverdrive.Margin = new System.Windows.Forms.Padding(6);
+            this.btnEverdrive.Location = new System.Drawing.Point(352, 393);
+            this.btnEverdrive.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.btnEverdrive.Name = "btnEverdrive";
-            this.btnEverdrive.Size = new System.Drawing.Size(206, 141);
+            this.btnEverdrive.Size = new System.Drawing.Size(158, 110);
             this.btnEverdrive.TabIndex = 36;
             this.btnEverdrive.Text = "Everdrive Sort";
             this.btnEverdrive.UseVisualStyleBackColor = true;
             this.btnEverdrive.Click += new System.EventHandler(this.btnEverdrive_Click);
             // 
+            // btnCreateM3uPlaylists
+            // 
+            this.btnCreateM3uPlaylists.Location = new System.Drawing.Point(352, 513);
+            this.btnCreateM3uPlaylists.Margin = new System.Windows.Forms.Padding(5);
+            this.btnCreateM3uPlaylists.Name = "btnCreateM3uPlaylists";
+            this.btnCreateM3uPlaylists.Size = new System.Drawing.Size(158, 110);
+            this.btnCreateM3uPlaylists.TabIndex = 37;
+            this.btnCreateM3uPlaylists.Text = "Create m3u playlists";
+            this.btnCreateM3uPlaylists.UseVisualStyleBackColor = true;
+            this.btnCreateM3uPlaylists.Click += new System.EventHandler(this.btnCreateM3uPlaylists_Click);
+            // 
             // Form2
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(13F, 32F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(901, 969);
+            this.ClientSize = new System.Drawing.Size(693, 757);
+            this.Controls.Add(this.btnCreateM3uPlaylists);
             this.Controls.Add(this.btnEverdrive);
             this.Controls.Add(this.btn1G1R);
             this.Controls.Add(this.chkZipInsteadOfFolders);
@@ -351,7 +360,7 @@
             this.Controls.Add(this.btnDatFolderSelect);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.btnDetectDupes);
-            this.Margin = new System.Windows.Forms.Padding(6);
+            this.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this.Name = "Form2";
             this.Text = "ROMSorter (Release 4)";
             this.Shown += new System.EventHandler(this.Form2_Shown);
@@ -387,5 +396,6 @@
         private System.Windows.Forms.CheckBox chkZipInsteadOfFolders;
         private System.Windows.Forms.Button btn1G1R;
         private System.Windows.Forms.Button btnEverdrive;
+        private System.Windows.Forms.Button btnCreateM3uPlaylists;
     }
 }

--- a/RomSorter5/Form2.cs
+++ b/RomSorter5/Form2.cs
@@ -411,5 +411,19 @@ namespace RomSorter5WinForms
             await Task.Factory.StartNew(() => CoreFunctions.EverdriveSort(p, txtRomPath.Text));
             UnlockButtons();
         }
+
+        private async void btnCreateM3uPlaylists_Click(object sender, EventArgs e)
+        {
+            var files = Directory.EnumerateFiles(txtRomPath.Text)
+                .Where(x => x.Contains("disc 1", StringComparison.CurrentCultureIgnoreCase)
+                && (x.Contains(".chd") || x.Contains(".iso") || x.Contains(".cue")))
+                .ToList();
+            progressBar1.Maximum = files.Count;
+
+            LockButtons();
+            Progress<string> p = new Progress<string>(s => { lblStatus.Text = s; if (progressBar1.Value < progressBar1.Maximum) progressBar1.Value++; });
+            await Task.Factory.StartNew(() => CoreFunctions.CreateM3uPlaylists(p, txtRomPath.Text));
+            UnlockButtons();
+        }
     }
 }


### PR DESCRIPTION
Hi from reddit (again),

Not sure if you're accepting pull requests but figured this was a relatively quick and easy thing to implement and might be useful to someone. 

It just looks for anything that looks like a multi-disc game (by literally  looking for "disc 1" in the filename) and then writes an m3u file with the disks in order. This is particularly useful for those moving to .chd files as unlike pbp you can't combine multiple disks into one chd, while most emulators support the m3u playlist approach. 

I've added the functionality as a separate button but it might be nice to have a tickbox to do this automatically when say converting CHDs or something. There's probably also merit to handling subfolders, so you can have say your game in a subfolder with the .m3u file above it, so various ROM scraping utilities (Like steam ROM manager) only sees the .m3u file. But I haven't got that far. 